### PR TITLE
Update vojtechruzicka.json

### DIFF
--- a/configs/vojtechruzicka.json
+++ b/configs/vojtechruzicka.json
@@ -5,11 +5,14 @@
   ],
   "stop_urls": [],
   "selectors": {
-    "lvl0": ".docSearch-content h1",
-    "lvl1": ".docSearch-content h2",
-    "lvl2": ".docSearch-content h3",
-    "lvl3": ".docSearch-content h4",
-    "lvl4": ".docSearch-content h5",
+    "lvl0": {
+      "selector": "",
+        "default_value": "Search Results"
+    },
+    "lvl1": ".docSearch-content h1",
+    "lvl2": ".docSearch-content h2",
+    "lvl3": ".docSearch-content h3",
+    "lvl4": ".docSearch-content h4",
     "text": ".docSearch-content p, .docSearch-content li"
   },
   "conversation_id": [


### PR DESCRIPTION
changed lvl 0 to be the same for all posts.

Currently, my results look like this, where each article has its own section:
![clipboard02](https://user-images.githubusercontent.com/7038612/41032409-99907052-6983-11e8-9b8e-f7027d386414.png)


And I want them all to be in the same category.
